### PR TITLE
Fix readme example spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ end
 ```ruby
 # Specifying Rack::LiveReload options.
 config.middleware.use(Rack::LiveReload,
-  min_delay        : 500,    # default 1000
-  max_delay        : 10_000, # default 60_000
-  live_reload_port : 56789,  # default 35729
-  live_reload_scheme : 'ws', # default ws, use wss for ssl
-  host             : 'myhost.cool.wow',
-  ignore           : [ %r{dont/modify\.html$} ]
+  min_delay:          500,    # default 1000
+  max_delay:          10_000, # default 60_000
+  live_reload_port:   56789,  # default 35729
+  live_reload_scheme: 'ws', # default ws, use wss for ssl
+  host:               'myhost.cool.wow',
+  ignore:             [ %r{dont/modify\.html$} ]
 )
 ```
 


### PR DESCRIPTION
The spacing in the readme is a syntax error, simple update to fix. 

``` ruby
SyntaxError: /Users/nick/src/railsapp/config/environments/development.rb:7: syntax error, unexpected ':', expecting ')'
    min_delay        : 500,    # default 1000
                     ^
/Users/nick/src/railsapp/config/environment.rb:5:in `<main>'
Tasks: TOP => db:prepare => db:load_config => environment
```