### PR TITLE
Headers must be lowercase in Rack 3.0

### DIFF
--- a/features/step_definitions/given/i_have_a_rack_app_with_live_reload.rb
+++ b/features/step_definitions/given/i_have_a_rack_app_with_live_reload.rb
@@ -2,6 +2,6 @@ Given /^I have a Rack app with Rack::LiveReload$/ do
   @app = Rack::Builder.new do
     use Rack::LiveReload
 
-    run lambda { |env| [ 200, { 'Content-Type' => 'text/html' }, [ "<html><head></head><body></body></html>" ] ] }
+    run lambda { |env| [ 200, { 'content-type' => 'text/html' }, [ "<html><head></head><body></body></html>" ] ] }
   end
 end

--- a/lib/rack/livereload.rb
+++ b/lib/rack/livereload.rb
@@ -27,10 +27,10 @@ module Rack
         processor = BodyProcessor.new(body, @options)
         processor.process!(env)
 
-        headers['Content-Length'] = processor.content_length.to_s
+        headers['content-length'] = processor.content_length.to_s
 
         if processor.livereload_added
-          headers['X-Rack-LiveReload'] = '1'
+          headers['x-rack-livereload'] = '1'
         end
 
         [ status, headers, processor.new_body ]
@@ -46,7 +46,7 @@ module Rack
                'application/swf'
              end
 
-      [ 200, { 'Content-Type' => type, 'Content-Length' => ::File.size(file).to_s }, [ ::File.read(file) ] ]
+      [ 200, { 'content-type' => type, 'content-length' => ::File.size(file).to_s }, [ ::File.read(file) ] ]
     end
   end
 end

--- a/lib/rack/livereload/processing_skip_analyzer.rb
+++ b/lib/rack/livereload/processing_skip_analyzer.rb
@@ -20,11 +20,11 @@ module Rack
       end
 
       def chunked?
-        @headers['Transfer-Encoding'] == 'chunked'
+        @headers['transfer-encoding'] == 'chunked'
       end
 
       def inline?
-        @headers['Content-Disposition'] =~ %r{^inline}
+        @headers['content-disposition'] =~ %r{^inline}
       end
 
       def ignored?
@@ -37,7 +37,7 @@ module Rack
       end
 
       def html?
-        @headers['Content-Type'] =~ %r{text/html|application/xhtml\+xml}
+        @headers['content-type'] =~ %r{text/html|application/xhtml\+xml}
       end
 
       def get?

--- a/spec/rack/livereload/processing_skip_analyzer_spec.rb
+++ b/spec/rack/livereload/processing_skip_analyzer_spec.rb
@@ -40,7 +40,7 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
     end
 
     context 'chunked response' do
-      let(:headers) { { 'Transfer-Encoding' => 'chunked' } }
+      let(:headers) { { 'transfer-encoding' => 'chunked' } }
 
       it { should be_chunked }
     end
@@ -48,7 +48,7 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
 
   describe '#inline?' do
     context 'inline disposition' do
-      let(:headers) { { 'Content-Disposition' => 'inline; filename=my_inlined_file' } }
+      let(:headers) { { 'content-disposition' => 'inline; filename=my_inlined_file' } }
 
       it { should be_inline }
     end
@@ -90,19 +90,19 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
 
   describe '#html?' do
     context 'HTML content' do
-      let(:headers) { { 'Content-Type' => 'text/html' } }
+      let(:headers) { { 'content-type' => 'text/html' } }
 
       it { should be_html }
     end
 
     context 'XHTML content' do
-      let(:headers) { { 'Content-Type' => 'application/xhtml+xml' } }
+      let(:headers) { { 'content-type' => 'application/xhtml+xml' } }
 
       it { should be_html }
     end
 
     context 'PDF content' do
-      let(:headers) { { 'Content-Type' => 'application/pdf' } }
+      let(:headers) { { 'content-type' => 'application/pdf' } }
 
       it { should_not be_html }
     end


### PR DESCRIPTION
Rack 3.0 headers are always lowercase. When rack-livereload looks for a `Content-Type` header, it finds nothing, assumes nothing is ever HTML, and never works. This fixes the issue.